### PR TITLE
cache: update entities to v8

### DIFF
--- a/base/src/entity/channel/message.rs
+++ b/base/src/entity/channel/message.rs
@@ -12,7 +12,7 @@ use crate::{
 use twilight_model::{
     channel::{
         embed::Embed,
-        message::{MessageFlags, MessageReaction, MessageType},
+        message::{MessageActivity, MessageFlags, MessageReaction, MessageType},
     },
     id::{ApplicationId, AttachmentId, ChannelId, GuildId, MessageId, RoleId, UserId, WebhookId},
 };
@@ -20,6 +20,7 @@ use twilight_model::{
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MessageEntity {
+    pub activity: Option<MessageActivity>,
     pub application_id: ApplicationId,
     pub attachments: Vec<AttachmentId>,
     pub author_id: UserId,

--- a/base/src/entity/gateway/presence.rs
+++ b/base/src/entity/gateway/presence.rs
@@ -9,9 +9,7 @@ use twilight_model::{
 pub struct PresenceEntity {
     pub activities: Vec<Activity>,
     pub client_status: ClientStatus,
-    pub game: Option<Activity>,
     pub guild_id: GuildId,
-    pub nick: Option<String>,
     pub status: Status,
     pub user_id: UserId,
 }

--- a/base/src/entity/guild/mod.rs
+++ b/base/src/entity/guild/mod.rs
@@ -40,8 +40,6 @@ pub struct GuildEntity {
     pub default_message_notifications: DefaultMessageNotificationLevel,
     pub description: Option<String>,
     pub discovery_splash: Option<String>,
-    pub embed_channel_id: Option<ChannelId>,
-    pub embed_enabled: Option<bool>,
     pub explicit_content_filter: ExplicitContentFilter,
     pub features: Vec<String>,
     pub icon: Option<String>,

--- a/base/src/entity/user/current_user.rs
+++ b/base/src/entity/user/current_user.rs
@@ -3,7 +3,10 @@ use crate::{
     repository::{ListEntitiesFuture, ListEntityIdsFuture, SingleEntityRepository},
     utils, Backend,
 };
-use twilight_model::id::{GuildId, UserId};
+use twilight_model::{
+    id::{GuildId, UserId},
+    user::{PremiumType, UserFlags},
+};
 
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -12,9 +15,12 @@ pub struct CurrentUserEntity {
     pub bot: bool,
     pub discriminator: String,
     pub email: Option<String>,
+    pub flags: Option<UserFlags>,
     pub id: UserId,
     pub mfa_enabled: bool,
     pub name: String,
+    pub premium_type: Option<PremiumType>,
+    pub public_flags: Option<UserFlags>,
     pub verified: bool,
 }
 

--- a/base/src/entity/voice/state.rs
+++ b/base/src/entity/voice/state.rs
@@ -18,6 +18,7 @@ pub struct VoiceStateEntity {
     pub self_stream: bool,
     pub session_id: String,
     pub suppress: bool,
+    pub token: Option<String>,
     pub user_id: UserId,
 }
 


### PR DESCRIPTION
This PR updates the fields in entity to match the current fields in
`twilight_model`.

Signed-off-by: Cassandra McCarthy <cassie@7596ff.com>
