### PR TITLE
cache: change application_id to Option

### DIFF
--- a/base/src/entity/channel/message.rs
+++ b/base/src/entity/channel/message.rs
@@ -21,7 +21,7 @@ use twilight_model::{
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MessageEntity {
     pub activity: Option<MessageActivity>,
-    pub application_id: ApplicationId,
+    pub application_id: Option<ApplicationId>,
     pub attachments: Vec<AttachmentId>,
     pub author_id: UserId,
     pub channel_id: ChannelId,


### PR DESCRIPTION
`twilight_model`'s `Message` struct has this field as an Option. Also, I accidentally pushed the branch to the twilight repo, my bad. Still getting used to github cli.