### PR TITLE
ci: fix tests

### DIFF
--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -36,7 +36,7 @@
 //! // that the backend implements.
 //! use futures_util::stream::StreamExt;
 //! use rarity_cache::{Cache, Repository};
-//! use rarity_cache_inmemory::InMemoryBackend;
+//! use rarity_cache_inmemory::{prelude::*, InMemoryBackend};
 //! use twilight_model::id::{GuildId, MessageId};
 //!
 //! # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/in-memory/src/lib.rs
+++ b/in-memory/src/lib.rs
@@ -6,7 +6,7 @@
 //! > (note that, of course, both the emoji and the user must be in the cache)
 //!
 //! ```rust,no_run
-//! use rarity_cache_inmemory::InMemoryCache;
+//! use rarity_cache_inmemory::{prelude::*, InMemoryCache};
 //! use twilight_model::id::EmojiId;
 //!
 //! # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -31,7 +31,7 @@
 //!
 //! ```rust,no_run
 //! use futures::StreamExt;
-//! use rarity_cache_inmemory::{InMemoryCache, Repository};
+//! use rarity_cache_inmemory::{prelude::*, InMemoryCache, Repository};
 //! use twilight_model::id::GuildId;
 //!
 //! # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
Fix the documentation tests by importing `twilight-cache-inmemory`'s prelude. Specifically this imports the entity-specific repositories.