### PR TITLE
chore!: update project namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Rarity Cache
+# Twilight Cache
 
-Rarity Cache is an entity/repository-based cache for the [`twilight-rs`]
+Twilight Cache is an entity/repository-based cache for the [`twilight-rs`]
 ecosystem. If you're not familiar with entities and repositories,
 [Microsoft has an article][docs:repo:microsoft] about it. The idea is that
 entities - things like guilds, channels, or users - contain data about
@@ -11,7 +11,7 @@ entries at the data source.
 
 ### Base Crate
 
-The primary crate is `rarity-cache`, which is a generic abstraction over any
+The primary crate is `twilight-cache`, which is a generic abstraction over any
 datastore backend. It can be built on top of to write backends for things like
 Redis, CouchDB, SQLite, in-process-memory, or anything else.
 
@@ -34,7 +34,7 @@ backend's repository implementations.
 
 ### Implementations
 
-Provided is the `rarity-cache-inmemory` implementation, which caches entities in
+Provided is the `twilight-cache-inmemory` implementation, which caches entities in
 the memory of the process. A Redis implementation is planned.
 
 ## Examples
@@ -43,7 +43,7 @@ Get a message by its ID, and then get a different message's author, knowing only
 the ID of both messages:
 
 ```rust
-use rarity_cache_inmemory::InMemoryCache;
+use twilight_cache_inmemory::InMemoryCache;
 use twilight_model::id::MessageId;
 
 let cache = InMemoryCache::new();
@@ -63,12 +63,12 @@ if let Some(author) = cache.messages.author(MessageId(456)).await? {
 
 ## Installation
 
-Add the following to your `Cargo.toml` to install the `rarity-cache-inmemory`
+Add the following to your `Cargo.toml` to install the `twilight-cache-inmemory`
 crate:
 
 ```toml
 [dependencies]
-rarity-cache-inmemory = { branch = "main", git = "https://github.com/rarity-rs/cache" }
+twilight-cache-inmemory = { branch = "main", git = "https://github.com/twilight-rs/cache" }
 ```
 
 ## License

--- a/base/Cargo.toml
+++ b/base/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 authors = ["Vivian Hellyer <vivian@hellyer.dev>"]
 edition = "2018"
-homepage = "https://github.com/rarity-rs/cache"
+homepage = "https://github.com/twilight-rs/cache"
 license = "ISC"
-name = "rarity-cache"
+name = "twilight-cache"
 readme = "../README.md"
-repository = "https://github.com/rarity-rs/cache.git"
+repository = "https://github.com/twilight-rs/cache.git"
 version = "0.1.0"
 
 [dependencies]
@@ -15,7 +15,7 @@ twilight-model = { default-features = false, version = "0.2" }
 
 [dev-dependencies]
 tokio = { default-features = false, features = ["macros", "rt-threaded"], version = "0.2" }
-rarity-cache-inmemory = { default-features = false, optional = false, path = "../in-memory" }
+twilight-cache-inmemory = { default-features = false, optional = false, path = "../in-memory" }
 
 [features]
 default = ["serde"]

--- a/base/src/cache.rs
+++ b/base/src/cache.rs
@@ -139,8 +139,8 @@ impl<T: Backend> Cache<T> {
     /// role repository to delete the role from the datastore:
     ///
     /// ```no_run
-    /// use rarity_cache::Cache;
-    /// use rarity_cache_inmemory::{InMemoryBackend, Repository};
+    /// use twilight_cache::Cache;
+    /// use twilight_cache_inmemory::{InMemoryBackend, Repository};
     /// use twilight_model::{
     ///     gateway::{event::Event, payload::RoleDelete},
     ///     id::{GuildId, RoleId},

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -1,6 +1,6 @@
-//! # rarity-cache
+//! # twilight-cache
 //!
-//! `rarity-cache` is an implementation of a generic cache to support any type
+//! `twilight-cache` is an implementation of a generic cache to support any type
 //! of datastore backend implementation. Implementations of backends can be
 //! anything. To name a few examples: a backend to work with a database like
 //! Cassandra or MongoDB, an in-memory database like Redis or memcached, or a
@@ -17,9 +17,9 @@
 //!
 //! # Backends
 //!
-//! Here's a list of backends supported by Rarity:
+//! Here's a list of backends supported by Twilight:
 //!
-//! - [`rarity-cache-inmemory`]: datastore in the process's memory
+//! - [`twilight-cache-inmemory`]: datastore in the process's memory
 //!
 //! # Usage
 //!
@@ -28,15 +28,15 @@
 //! [`Cache`] to update the cache with new event data and retrieve things like
 //! users or emojis.
 //!
-//! Here's an example of using the cache with the [`rarity-cache-inmemory`]
+//! Here's an example of using the cache with the [`twilight-cache-inmemory`]
 //! backend:
 //!
 //! ```rust,no_run
 //! // Import the cache and the Repository trait to work with the repositories
 //! // that the backend implements.
 //! use futures_util::stream::StreamExt;
-//! use rarity_cache::{Cache, Repository};
-//! use rarity_cache_inmemory::InMemoryBackend;
+//! use twilight_cache::{Cache, Repository};
+//! use twilight_cache_inmemory::InMemoryBackend;
 //! use twilight_model::id::{GuildId, MessageId};
 //!
 //! # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -93,7 +93,7 @@
 //! The `serde` feature can be disabled to remove the `Deserialize` and
 //! `Serialize` implementations on entities. It is enabled by default.
 //!
-//! [`rarity-cache-inmemory`]: ../rarity_cache_inmemory/index.html
+//! [`twilight-cache-inmemory`]: ../twilight_cache_inmemory/index.html
 //! [docs:repo:microsoft]: https://docs.microsoft.com/en-us/dotnet/architecture/microservices/microservice-ddd-cqrs-patterns/infrastructure-persistence-layer-design
 
 #![deny(

--- a/in-memory/Cargo.toml
+++ b/in-memory/Cargo.toml
@@ -2,14 +2,14 @@
 authors = ["Vivian Hellyer <vivian@hellyer.dev>"]
 edition = "2018"
 license = "ISC"
-name = "rarity-cache-inmemory"
+name = "twilight-cache-inmemory"
 version = "0.1.0"
 
 [dependencies]
 bitflags = { default-features = false, version = "1" }
 dashmap = { default-features = false, version = "3" }
 futures-util = { default-features = false, features = ["std"], version = "0.3" }
-rarity-cache = { default-features = false, path = "../base" }
+twilight-cache = { default-features = false, path = "../base" }
 twilight-model = { default-features = false, version = "0.2" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
 

--- a/in-memory/src/lib.rs
+++ b/in-memory/src/lib.rs
@@ -6,7 +6,7 @@
 //! > (note that, of course, both the emoji and the user must be in the cache)
 //!
 //! ```rust,no_run
-//! use rarity_cache_inmemory::InMemoryCache;
+//! use twilight_cache_inmemory::InMemoryCache;
 //! use twilight_model::id::EmojiId;
 //!
 //! # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -31,7 +31,7 @@
 //!
 //! ```rust,no_run
 //! use futures::StreamExt;
-//! use rarity_cache_inmemory::{InMemoryCache, Repository};
+//! use twilight_cache_inmemory::{InMemoryCache, Repository};
 //! use twilight_model::id::GuildId;
 //!
 //! # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -67,14 +67,14 @@
 )]
 #![allow(clippy::module_name_repetitions, clippy::must_use_candidate)]
 
-pub extern crate rarity_cache as cache;
+pub extern crate twilight_cache as cache;
 
 pub mod config;
 pub mod prelude;
 pub mod repository;
 
 #[doc(no_inline)]
-pub use rarity_cache::Repository;
+pub use twilight_cache::Repository;
 
 use self::{
     config::{Config, EntityType},
@@ -88,7 +88,7 @@ use self::{
     },
 };
 use dashmap::DashMap;
-use rarity_cache::{
+use twilight_cache::{
     entity::{
         channel::{
             AttachmentEntity, CategoryChannelEntity, GroupEntity, MessageEntity,
@@ -110,12 +110,12 @@ use std::{
 };
 use twilight_model::id::{AttachmentId, ChannelId, EmojiId, GuildId, MessageId, RoleId, UserId};
 
-/// Alias over `rarity_cache::Cache` which uses the [`InMemoryBackend`].
+/// Alias over `twilight_cache::Cache` which uses the [`InMemoryBackend`].
 ///
 /// This allows you to use the in-memory backend like:
 ///
 /// ```
-/// use rarity_cache_inmemory::{InMemoryCache, Repository};
+/// use twilight_cache_inmemory::{InMemoryCache, Repository};
 /// use twilight_model::id::UserId;
 ///
 /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -220,12 +220,12 @@ impl InMemoryBackend {
     ///
     /// # Examples
     ///
-    /// Create a new cache backend and then create a `rarity_cache::Cache`
+    /// Create a new cache backend and then create a `twilight_cache::Cache`
     /// with it:
     ///
     /// ```
-    /// use rarity_cache::Cache;
-    /// use rarity_cache_inmemory::InMemoryBackend;
+    /// use twilight_cache::Cache;
+    /// use twilight_cache_inmemory::InMemoryBackend;
     ///
     /// let backend = InMemoryBackend::new();
     /// let cache = Cache::with_backend(backend);
@@ -235,7 +235,7 @@ impl InMemoryBackend {
     /// shorthand for above:
     ///
     /// ```
-    /// use rarity_cache_inmemory::InMemoryCache;
+    /// use twilight_cache_inmemory::InMemoryCache;
     ///
     /// let cache = InMemoryCache::new();
     /// ```
@@ -257,7 +257,7 @@ impl InMemoryBackend {
     /// and only caches messages and users:
     ///
     /// ```
-    /// use rarity_cache_inmemory::{config::EntityType, InMemoryBackend};
+    /// use twilight_cache_inmemory::{config::EntityType, InMemoryBackend};
     ///
     /// let mut builder = InMemoryBackend::builder();
     /// builder
@@ -280,10 +280,10 @@ impl InMemoryBackend {
     }
 }
 
-/// In memory implementation of a `rarity_cache` backend.
+/// In memory implementation of a `twilight_cache` backend.
 ///
 /// **Note**: you should probably not be using the trait's methods directly, and
-/// should wrap a backend instance in `rarity_cache`'s `Cache` and use its
+/// should wrap a backend instance in `twilight_cache`'s `Cache` and use its
 /// methods and fields instead.
 impl Backend for InMemoryBackend {
     type Error = InMemoryBackendError;
@@ -382,7 +382,7 @@ impl Backend for InMemoryBackend {
 #[cfg(test)]
 mod tests {
     use super::{InMemoryBackend, InMemoryBackendBuilder, InMemoryBackendError, InMemoryCache};
-    use rarity_cache::Backend;
+    use twilight_cache::Backend;
     use static_assertions::{assert_impl_all, assert_obj_safe};
     use std::{error::Error, fmt::Debug};
 

--- a/in-memory/src/prelude.rs
+++ b/in-memory/src/prelude.rs
@@ -3,7 +3,7 @@
 #[doc(no_inline)]
 pub use super::{InMemoryBackend, InMemoryBackendError, InMemoryCache};
 #[doc(no_inline)]
-pub use rarity_cache::{
+pub use twilight_cache::{
     entity::{
         channel::{
             attachment::AttachmentRepository as _,

--- a/in-memory/src/repository.rs
+++ b/in-memory/src/repository.rs
@@ -4,7 +4,7 @@ use futures_util::{
     future::{self, FutureExt},
     stream::{self, StreamExt},
 };
-use rarity_cache::{
+use twilight_cache::{
     entity::{
         channel::{
             attachment::{AttachmentEntity, AttachmentRepository},

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Vivian Hellyer <vivian@hellyer.dev>"]
 edition = "2018"
 license = "ISC"
-name = "rarity-cache-redis"
+name = "twilight-cache-redis"
 version = "0.1.0"
 
 [dependencies]

--- a/unqlite/Cargo.toml
+++ b/unqlite/Cargo.toml
@@ -2,12 +2,12 @@
 authors = ["Vivian Hellyer <vivian@hellyer.dev>"]
 edition = "2018"
 license = "ISC"
-name = "rarity-cache-unqlite"
+name = "twilight-cache-unqlite"
 version = "0.1.0"
 
 [dependencies]
 futures-util = { default-features = false, features = ["std"], version = "0.3" }
-rarity-cache = { default-features = false, path = "../base" }
+twilight-cache = { default-features = false, path = "../base" }
 serde = { default-features = false, version = "1.0" }
 serde_cbor = { default-features = false, features = ["std"], version = "0.11" }
 twilight-model = { default-features = false, version = "0.2" }

--- a/unqlite/src/lib.rs
+++ b/unqlite/src/lib.rs
@@ -1,5 +1,5 @@
 use futures_util::future::{self, FutureExt};
-use rarity_cache::{
+use twilight_cache::{
     entity::{
         channel::{
             attachment::{AttachmentEntity, AttachmentRepository},
@@ -200,7 +200,7 @@ impl AttachmentRepository<UnqliteBackend> for UnqliteRepository<AttachmentEntity
 impl CategoryChannelRepository<UnqliteBackend> for UnqliteRepository<CategoryChannelEntity> {}
 
 impl CurrentUserRepository<UnqliteBackend> for UnqliteRepository<CurrentUserEntity> {
-    fn guild_ids(&self) -> rarity_cache::repository::ListEntityIdsFuture<'_, GuildId, Error> {
+    fn guild_ids(&self) -> twilight_cache::repository::ListEntityIdsFuture<'_, GuildId, Error> {
         unimplemented!("not implemented by this backend");
     }
 }
@@ -213,28 +213,28 @@ impl GuildRepository<UnqliteBackend> for UnqliteRepository<GuildEntity> {
     fn channel_ids(
         &self,
         _: GuildId,
-    ) -> rarity_cache::repository::ListEntityIdsFuture<'_, ChannelId, Error> {
+    ) -> twilight_cache::repository::ListEntityIdsFuture<'_, ChannelId, Error> {
         unimplemented!("not implemented by this backend");
     }
 
     fn channels(
         &self,
         _: GuildId,
-    ) -> ListEntitiesFuture<'_, rarity_cache::entity::channel::GuildChannelEntity, Error> {
+    ) -> ListEntitiesFuture<'_, twilight_cache::entity::channel::GuildChannelEntity, Error> {
         unimplemented!("not implemented by this backend");
     }
 
     fn emoji_ids(
         &self,
         _: GuildId,
-    ) -> rarity_cache::repository::ListEntityIdsFuture<'_, EmojiId, Error> {
+    ) -> twilight_cache::repository::ListEntityIdsFuture<'_, EmojiId, Error> {
         unimplemented!("not implemented by this backend");
     }
 
     fn member_ids(
         &self,
         _: GuildId,
-    ) -> rarity_cache::repository::ListEntityIdsFuture<'_, UserId, Error> {
+    ) -> twilight_cache::repository::ListEntityIdsFuture<'_, UserId, Error> {
         unimplemented!("not implemented by this backend");
     }
 
@@ -245,7 +245,7 @@ impl GuildRepository<UnqliteBackend> for UnqliteRepository<GuildEntity> {
     fn presence_ids(
         &self,
         _: GuildId,
-    ) -> rarity_cache::repository::ListEntityIdsFuture<'_, UserId, Error> {
+    ) -> twilight_cache::repository::ListEntityIdsFuture<'_, UserId, Error> {
         unimplemented!("not implemented by this backend");
     }
 
@@ -256,14 +256,14 @@ impl GuildRepository<UnqliteBackend> for UnqliteRepository<GuildEntity> {
     fn role_ids(
         &self,
         _: GuildId,
-    ) -> rarity_cache::repository::ListEntityIdsFuture<'_, RoleId, Error> {
+    ) -> twilight_cache::repository::ListEntityIdsFuture<'_, RoleId, Error> {
         unimplemented!("not implemented by this backend");
     }
 
     fn voice_state_ids(
         &self,
         _: GuildId,
-    ) -> rarity_cache::repository::ListEntityIdsFuture<'_, UserId, Error> {
+    ) -> twilight_cache::repository::ListEntityIdsFuture<'_, UserId, Error> {
         unimplemented!("not implemented by this backend");
     }
 
@@ -292,19 +292,19 @@ impl UserRepository<UnqliteBackend> for UnqliteRepository<UserEntity> {
     fn guild_ids(
         &self,
         _: UserId,
-    ) -> rarity_cache::repository::ListEntityIdsFuture<'_, GuildId, Error> {
+    ) -> twilight_cache::repository::ListEntityIdsFuture<'_, GuildId, Error> {
         unimplemented!("not implemented by this backend")
     }
 }
 
-/// `rarity-cache` backend for the [UnQLite] database.
+/// `twilight-cache` backend for the [UnQLite] database.
 ///
 /// [UnQLite]: https://docs.rs/unqlite
 #[derive(Clone)]
 pub struct UnqliteBackend(Arc<UnQLite>);
 
 impl UnqliteBackend {
-    /// Create a new `rarity-cache` UnQLite backend with a provided instance.
+    /// Create a new `twilight-cache` UnQLite backend with a provided instance.
     pub fn new(unqlite: UnQLite) -> Self {
         Self(Arc::new(unqlite))
     }


### PR DESCRIPTION
Update the namespace of the project from `rarity` to `twilight`, as the project was moved from the `rarity-rs` organization to `twilight-rs`.

BREAKING CHANGES: Crate names' prefixes have been changed from `rarity` to `twilight`, e.g. `rarity-cache-unqlite` to `twilight-cache-unqlite`.